### PR TITLE
Customizacao Statusbar nofolder

### DIFF
--- a/themes/PSR Theme-color-theme.json
+++ b/themes/PSR Theme-color-theme.json
@@ -13,14 +13,16 @@
 		"sideBarSectionHeader.foreground": "#4cb88a",
 		"statusBar.background": "#4cb88a",
 		"statusBar.foreground": "#1a4c37",
+		"statusBar.noFolderBackground": "#4cb88a",
+		"statusBar.noFolderForeground": "#1a4c37",
 		"activityBar.background": "#1a4c37",
 		"activityBar.foreground": "#4cb88a",
 		"activityBar.border": "#4cb88a",
 		"activityBarBadge.background": "#ec8618",
 		"activityBarBadge.foreground": "#ffffff"
+
 	},
-	"tokenColors":[
-		{
+	"tokenColors": [{
 			"name": "Comment",
 			"scope": "comment",
 			"settings": {
@@ -52,7 +54,7 @@
 		{
 			"name": "User-defined constant",
 			"scope": [
-				"constant.character", 
+				"constant.character",
 				"constant.other"
 			],
 			"settings": {


### PR DESCRIPTION
**Problema**: Quando se abre um arquivo sem pasta no vscode o statusbar fica com o valor do tema padrão exemplo: 

![image](https://user-images.githubusercontent.com/2348869/84825128-566d2d80-aff7-11ea-9e82-d86c27f566d2.png)

Esse PR corrige o estilo quando abre sem pasta.
